### PR TITLE
Fix typos

### DIFF
--- a/infrastructure/index.html
+++ b/infrastructure/index.html
@@ -169,7 +169,7 @@
 <h2><a id="security"></a> Security</h2>
 <p>We take security very serious and do our best to protect your data.</p>
 <ul>
-<li>CERN Data Centre: Our data centres is located on CERN premises and all physical access is restricted to a limited number of staff with appropriate training and who have been granted access in line with their professional duties (e.g. Zendo staff do not have physical access to the CERN Data Centre) .</li>
+<li>CERN Data Centre: Our data centres is located on CERN premises and all physical access is restricted to a limited number of staff with appropriate training and who have been granted access in line with their professional duties (e.g. Zenodo staff do not have physical access to the CERN Data Centre) .</li>
 <li>Servers: Our servers are managed according to the CERN Security Baseline for Servers, meaning e.g. remote access to our servers are restricted to Zenodo staff with appropriate training, and the operating system and installed applications are kept updated with latest security patches via our automatic configuration management system Puppet.</li>
 <li>Network: CERN Security Team runs both host and network based intrusion detection systems and monitors the traffic flow, pattern and contents into and out of CERN networks in order to detect attacks. All access to zenodo.org happens over HTTPS, except for static documentation pages which are hosted on GitHub Pages.</li>
 <li>Data: Zenodo stores user passwords using strong cryptographic password hashing algorithms (currently PBKDF2+SHA512). Users’ access tokens to GitHub and ORCID are stored encrypted and can only be decrypted with the application’s secret key.</li>

--- a/principles/index.html
+++ b/principles/index.html
@@ -140,7 +140,7 @@ protocol by the record identifier and the collection name.</li>
 </ul>
 </li>
 <li><strong>A1.1</strong>: the protocol is open, free, and universally implementable<ul>
-<li>See point A1. OAI-PMH and REST are open, free and univesal protocols for information retrieval on the web.</li>
+<li>See point A1. OAI-PMH and REST are open, free and universal protocols for information retrieval on the web.</li>
 </ul>
 </li>
 <li><strong>A1.2</strong>: the protocol allows for an authentication and authorization procedure, where necessary<ul>
@@ -148,7 +148,7 @@ protocol by the record identifier and the collection name.</li>
 </ul>
 </li>
 <li><strong>A2</strong>: metadata are accessible, even when the data are no longer available<ul>
-<li>Data and metadta will be retained for the lifetime of the repository.
+<li>Data and metadata will be retained for the lifetime of the repository.
 This is currently the lifetime of the host laboratory CERN, which currently has an experimental programme defined for the next 20 years at least.</li>
 <li>Metadata are stored in high-availability database servers at CERN, which are separate to the data itself.</li>
 </ul>
@@ -165,7 +165,7 @@ This is currently the lifetime of the host laboratory CERN, which currently has 
 </ul>
 </li>
 <li><strong>I3</strong>: (meta)data include qualified references to other (meta)data<ul>
-<li>Each referrenced external piece of metadata is qualified by a resolvable URL.</li>
+<li>Each referenced external piece of metadata is qualified by a resolvable URL.</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
👋 Not sure about.zenodo.org is actually _maintained_ in html or that this repository is just the output of a static website generator, but I noticed the following typos in the about/principles section and I like the work Zenodo is doing, so wanted to fix them.